### PR TITLE
add seminar video

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,11 @@
             <div class="col-lg-12">
               <img src="img/application.png" width="100%">
               <hr>
+              <div class="row text-center pb-4">
+                <div class="col-lg-12">
+                  <iframe width="560" height="315" src="https://www.youtube.com/embed/iM5p0wq7fwU" title="YouTube video player" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                </div>
+              </div>
               <p>Once a week for 90 minutes, meet with fellow developers, challenge yourself, 
                 and receive guidance from current contributors. Weekly prep will take anywhere from 4-6 hours.</p>
               <p>Groups will have anywhere from 10-25 participants with rotating discussion groups of 3-5. Participants share a dedicated channel on the Chaincode Learning Slack workspace and those who complete the program are invited to our seminar alum community.</p>


### PR DESCRIPTION
Looks like this:

<img width="989" alt="Screen Shot 2022-10-18 at 5 31 56 PM" src="https://user-images.githubusercontent.com/755825/196548944-60df5c85-d11b-4adc-8c93-966e43e13984.png">
