### PR TITLE
Add mailto: prefix to contact email link in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@
         <div class="row justify-content-center">
           <div class="col-md-4">
             <span class="copyright">Copyright &copy; <a href="https://chaincode.com">Chaincode Labs</a> 2022</span>
-            <a href="learning@chaincode.com">learning@chaincode.com</a>
+            <a href="mailto:learning@chaincode.com">learning@chaincode.com</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This pull request adds the mailto: prefix to the contact email link in the footer. When users click on the email link, their default email client will now open with the recipient's email address pre-filled. This makes it easier and more convenient for users to get in touch with the contact email provided.